### PR TITLE
Unicode space fix

### DIFF
--- a/apps/conversion/conversionfunctions.js
+++ b/apps/conversion/conversionfunctions.js
@@ -366,14 +366,14 @@ function convertNumbers2Char ( str, type ) {
 	// type: string enum [none, hex, dec, utf8, utf16], what to treat numbers as
 	
 	if (type == 'hex') {
-		str = str.replace(/\s*(\b[A-Fa-f0-9]{1,6}\b)\s*/g, 
+		str = str.replace(/\s*,?\s*(\b[A-Fa-f0-9]{1,6}\b)\s*,?\s*/g, 
 					function(matchstr, parens) {
 						return hex2char(parens);
 						}
 						);
 		}
 	else if (type == 'dec') {
-		str = str.replace(/\s*(\b[0-9]+\b)\s*/g, 
+		str = str.replace(/\s*,?\s*(\b[0-9]+\b)\s*,?\s*/g, 
 					function(matchstr, parens) {
 						return dec2char(parens);
 						}

--- a/apps/conversion/conversionfunctions.js
+++ b/apps/conversion/conversionfunctions.js
@@ -366,31 +366,16 @@ function convertNumbers2Char ( str, type ) {
 	// type: string enum [none, hex, dec, utf8, utf16], what to treat numbers as
 	
 	if (type == 'hex') {
-		str = str.replace(/(\b[A-Fa-f0-9]{1,6}\b)/g, 
+		str = str.replace(/\s*(\b[A-Fa-f0-9]{1,6}\b)\s*/g, 
 					function(matchstr, parens) {
 						return hex2char(parens);
 						}
 						);
 		}
 	else if (type == 'dec') {
-		str = str.replace(/(\b[0-9]+\b)/g, 
+		str = str.replace(/\s*(\b[0-9]+\b)\s*/g, 
 					function(matchstr, parens) {
 						return dec2char(parens);
-						}
-						);
-		}
-	else if (type == 'utf8') {
-		str = str.replace(/(( [A-Fa-f0-9]{2})+)/g, 
-		//str = str.replace(/((\b[A-Fa-f0-9]{2}\b)+)/g, 
-					function(matchstr, parens) {
-						return convertUTF82Char(parens); 
-						}
-						);
-		}
-	else if (type == 'utf16') {
-		str = str.replace(/(( [A-Fa-f0-9]{1,6})+)/g, 
-					function(matchstr, parens) {
-						return convertUTF162Char(parens);
 						}
 						);
 		}


### PR DESCRIPTION
Make more of the 'convert' buttons cleanly reversible.

Before, pressing the convert buttons that used `convertNumbers2Char` would leave the whitespace in the resulting string, causing repeated alternating clicks of, for example, the "Characters" Convert button and the "Decimal code points" Convert button to double the number of spaces in the string every cycle.

An additional commit was included that allows support of comma-separated character codes in the decimal and hexadecimal character code boxes. (For example, "9584, 40,32,865,176   , 32,  860, 662, 32,  865    ,176, 32, 41, 12388, 9472, 9472, 9734, 12539, 65439" will now be converted to the characters with the numeric character codes and everything else is discarded.)

There are still some issues with the `U+`... and `0x`... notation conversions when they allow additional characters to be included since they are not proper escapes; changes to those fields should be more carefully considered.