### PR TITLE
[conversion/js] Apply ES6 style to BMP code-points

### DIFF
--- a/apps/conversion/conversionfunctions.js
+++ b/apps/conversion/conversionfunctions.js
@@ -964,6 +964,10 @@ function convertCharStr2jEsc ( str, parameters ) {
 					if (cc > 0x1f && cc < 0x7F) { 
 						outputString += String.fromCharCode(cc)
 						}
+                                        else if (parameters.match(/es6styleSC/)) {
+						pad = cc.toString(16).toUpperCase();
+                                                outputString += '\\u{'+pad+'}'
+                                                }
 					else { 
 						pad = cc.toString(16).toUpperCase();
 						while (pad.length < 4) { pad = '0'+pad; }


### PR DESCRIPTION
ES6 style escaping for JS is considered to be more legible in general because of the brackets, and is generally expected to be used for both BMP and non-BMP groups when possible.

At the moment, the option only works on non-BMP code-points. This patch also enables it for BPM chars.

To prevent too much over-head in the ES6 style, it's generally expected to not lead the numbers with zero, resulting in shorter byte length in average use cases.

In action:
<img width="654" alt="screen shot 2017-04-25 at 12 11 39 pm" src="https://cloud.githubusercontent.com/assets/37169/25398244/e5020ee2-29b0-11e7-9044-2175ca2771a4.png">
