### PR TITLE
[conversion/rust] Remove zero-padding from ES6-style escaping

### DIFF
--- a/apps/conversion/conversionfunctions.js
+++ b/apps/conversion/conversionfunctions.js
@@ -1032,7 +1032,6 @@ function convertCharStr2Rust ( str, parameters ) {
 						}
 					else { 
 						pad = cc.toString(16).toUpperCase();
-						while (pad.length < 4) { pad = '0'+pad; }
 						outputString += '\\u{'+pad+'}'
 						}
 				}


### PR DESCRIPTION
In Rust, it's recommended to use short (non-zero-padded) code-points
inside ES6-style escaping sequences (`\u{...}`), as it reduces the
length of the literal, and works better on the eyes for average use
cases, while mechanical parsing remains still fairly easy.

See examples in the Rust RFC and related discussion:
* https://github.com/rust-lang/rfcs/blob/master/text/0446-es6-unicode-escapes.md
* https://github.com/rust-lang/rfcs/pull/446
* https://github.com/rust-lang/rust/issues/19739

In action:
<img width="1290" alt="screen shot 2017-04-25 at 12 25 53 pm" src="https://cloud.githubusercontent.com/assets/37169/25398875/232a0f2e-29b3-11e7-93fb-33fe4e7e1eaa.png">
