### PR TITLE
[scripts/arabic/block] Fix spelling for U+0670 example

### DIFF
--- a/scripts/arabic/block.html
+++ b/scripts/arabic/block.html
@@ -1466,7 +1466,7 @@ onChange="setIndexFont(document.querySelector('#slfontswitchfont').value, this.v
       <div class="notes">
         <div class="letter arabic">
           <p><span class="title">Arabic</span> diacritic</p>
-          <p>Used in certain Arabic words such as <span class="ex" lang="ar" dir="rtl">هٰذَا</span> <span class="meaning">this</span> or <span class="ex" lang="ar" dir="rtl">ذٰلِكَ</span> <span class="meaning">that</span>, and not forgetting <span class="ex" lang="ar" dir="rtl">اللّهٰ</span> <span class="meaning">Allah</span>.</p>
+          <p>Used in certain Arabic words such as <span class="ex" lang="ar" dir="rtl">هٰذَا</span> <span class="meaning">this</span> or <span class="ex" lang="ar" dir="rtl">ذٰلِكَ</span> <span class="meaning">that</span>, and not forgetting <span class="ex" lang="ar" dir="rtl">اللّٰه</span> <span class="meaning">Allah</span>.</p>
         </div>
         <div class="letter urdu">
           <p><span class="title">Urdu</span> vowel</p>


### PR DESCRIPTION
In the word "allah", U+0670 comes before HEH, not after, and that's how it gets placed on the SHADDAH.

```
Used in certain Arabic words such as هٰذَا this or ذٰلِكَ that, and not forgetting اللّٰه Allah.
```

<img width="1014" alt="screen shot 2017-04-27 at 1 48 37 pm" src="https://cloud.githubusercontent.com/assets/37169/25499185/45d40a2c-2b50-11e7-8568-78ce97b40bff.png">
